### PR TITLE
Contract validation

### DIFF
--- a/src/__tests__/general.test.ts
+++ b/src/__tests__/general.test.ts
@@ -112,13 +112,7 @@ describe("General service", () => {
         const orgList = await generalAPI.listOrganizations();
 
         expect(orgList.status).toBe(200);
-     //  expect(orgList.data).toEqual(expect.arrayContaining([expect.objectContaining({tdei_org_id:'c552d5d1-0719-4647-b86d-6ae9b25327b7'})]));
-
-        expect(orgList.data).toMatchObject(<Organization>{
-          tdei_org_id: 'c552d5d1-0719-4647-b86d-6ae9b25327b7',
-          org_name: expect.any(String),
-          polygon: {}
-        })
+        expect(orgList.data).toEqual(expect.arrayContaining([expect.objectContaining({tdei_org_id:'c552d5d1-0719-4647-b86d-6ae9b25327b7'})]));
       })
     })
 

--- a/src/__tests__/general.test.ts
+++ b/src/__tests__/general.test.ts
@@ -1,7 +1,8 @@
-import { GeneralApi } from "tdei-client";
+import { GeneralApi, Organization, RecordStatus, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import { AxiosError } from "axios";
 import { isAxiosError } from "axios";
+import exp from "constants";
 
 
 describe("General service", () => {
@@ -34,7 +35,15 @@ describe("General service", () => {
         expect(versions.status).toBe(200);
         expect(versions.data.versions).not.toBeNull();
 
+      versions.data.versions?.forEach(version => {
+        expect(version).toMatchObject(<VersionSpec>{
+          version: expect.any(String),
+          documentation: expect.any(String),
+          specification: expect.any(String)
+        });
       })
+      })
+
       it('When no token is provided, expect to 401 status in return', async () => {
 
         let generalAPI = new GeneralApi(Utility.getConfiguration());
@@ -89,15 +98,28 @@ describe("General service", () => {
         expect(orgList.status).toBe(200);
         expect(Array.isArray(orgList.data)).toBe(true);
 
+        orgList.data.forEach(data => {
+          expect(data).toMatchObject(<Organization>{
+            tdei_org_id: expect.any(String),
+            org_name: expect.any(String),
+            polygon: {}
+          })
+        })
       })
+
       it('When valid token provided, expect to return 200 status and contain orgId that is predefined ', async ()=> {
         let generalAPI = new GeneralApi(configuration);
         const orgList = await generalAPI.listOrganizations();
 
         expect(orgList.status).toBe(200);
-        expect(orgList.data).toEqual(expect.arrayContaining([expect.objectContaining({tdei_org_id:'c552d5d1-0719-4647-b86d-6ae9b25327b7'})]));
-      })
+     //  expect(orgList.data).toEqual(expect.arrayContaining([expect.objectContaining({tdei_org_id:'c552d5d1-0719-4647-b86d-6ae9b25327b7'})]));
 
+        expect(orgList.data).toMatchObject(<Organization>{
+          tdei_org_id: 'c552d5d1-0719-4647-b86d-6ae9b25327b7',
+          org_name: expect.any(String),
+          polygon: {}
+        })
+      })
     })
 
     describe('Validation', ()=>{
@@ -121,8 +143,12 @@ describe("General service", () => {
         const recordStatus = await generalAPI.getStatus(recordId);
 
         expect(recordStatus.status).toBe(200);
-        expect(recordStatus.data).toMatchObject({tdeiRecordId:recordId});
-
+        expect(recordStatus.data).toMatchObject(<RecordStatus>{
+          tdeiRecordId: recordId,
+          stage: expect.any(String),
+          status: expect.any(String),
+          isComplete: expect.any(Boolean)
+        })
       })
     })
 

--- a/src/__tests__/general.test.ts
+++ b/src/__tests__/general.test.ts
@@ -102,7 +102,7 @@ describe("General service", () => {
           expect(data).toMatchObject(<Organization>{
             tdei_org_id: expect.any(String),
             org_name: expect.any(String),
-            polygon: {}
+            polygon: expect.anything()
           })
         })
       })

--- a/src/__tests__/gtfsflex.test.ts
+++ b/src/__tests__/gtfsflex.test.ts
@@ -115,7 +115,7 @@ describe('GTFS Flex service', ()=>{
                 expect(element).toMatchObject(<GtfsFlexDownload>{
                     tdei_record_id: expect.any(String),
                     tdei_org_id: expect.any(String),
-                    tdei_service_id: '801018f7-db32-4085-bbae-5339fa094cce',
+                    tdei_service_id: tdei_service_id,
                     collected_by: expect.any(String),
                     collection_date: expect.any(String),
                 collection_method: expect.any(String),

--- a/src/__tests__/gtfsflex.test.ts
+++ b/src/__tests__/gtfsflex.test.ts
@@ -1,6 +1,6 @@
 
 
-import {  GeneralApi, GeoJsonObjectTypeEnum, GTFSFlexApi, GtfsFlexDownload, GtfsFlexDownloadCollectionMethodEnum, GtfsFlexDownloadDataSourceEnum, GtfsFlexServiceModel, GtfsFlexUpload, VersionSpec } from "tdei-client";
+import {  Feature, GeneralApi, GeoJsonObject, GeoJsonObjectTypeEnum, GTFSFlexApi, GtfsFlexDownload, GtfsFlexDownloadCollectionMethodEnum, GtfsFlexDownloadDataSourceEnum, GtfsFlexServiceModel, GtfsFlexUpload, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import path from "path";
@@ -74,7 +74,7 @@ describe('GTFS Flex service', ()=>{
                 data_source: expect.any(String),
                 //TODO:
               //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
-               polygon: {},
+               polygon: expect.anything() as null | GeoJsonObject,
                flex_schema_version: expect.any(String),
                download_url: expect.any(String)
                 })
@@ -128,7 +128,7 @@ describe('GTFS Flex service', ()=>{
                 data_source: expect.any(String),
                 //TODO:
               //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
-               polygon: {},
+              polygon: expect.anything() as null | GeoJsonObject,
                flex_schema_version: expect.any(String),
                download_url: expect.any(String)
                 })
@@ -163,7 +163,7 @@ describe('GTFS Flex service', ()=>{
                 data_source: expect.any(String),
                 //TODO:
               //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
-               polygon: {},
+              polygon: expect.anything() as null | GeoJsonObject,
                flex_schema_version: expect.any(String),
                download_url: expect.any(String)
                 })
@@ -262,7 +262,7 @@ describe('GTFS Flex service', ()=>{
                 expect(Array.isArray(services.data)).toBe(true);
                 services.data.forEach(element => {
                     expect(element).toMatchObject(<GtfsFlexServiceModel>{
-                        polygon: {},
+                       polygon: expect.anything() as null | GeoJsonObject,
                         service_name: expect.any(String),
                         tdei_service_id: expect.any(String)
                     })

--- a/src/__tests__/gtfsflex.test.ts
+++ b/src/__tests__/gtfsflex.test.ts
@@ -1,6 +1,6 @@
 
 
-import {  GeneralApi, GTFSFlexApi, GtfsFlexUpload } from "tdei-client";
+import {  GeneralApi, GeoJsonObjectTypeEnum, GTFSFlexApi, GtfsFlexDownload, GtfsFlexDownloadCollectionMethodEnum, GtfsFlexDownloadDataSourceEnum, GtfsFlexServiceModel, GtfsFlexUpload, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import path from "path";
@@ -57,7 +57,28 @@ describe('GTFS Flex service', ()=>{
 
             expect(filesResponse.status).toBe(200)
             expect(Array.isArray(filesResponse.data)).toBe(true);
-
+            filesResponse.data.forEach(element => {
+                expect(element).toMatchObject(<GtfsFlexDownload>{
+                    tdei_record_id: expect.any(String),
+                    tdei_org_id: expect.any(String),
+                    tdei_service_id: expect.any(String),
+                    collected_by: expect.any(String),
+                    collection_date: expect.any(String),
+                collection_method: expect.any(String),
+                //TODO:
+                  //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
+                  valid_from: expect.any(String),
+                  valid_to: expect.any(String),
+                  //TODO:
+                //  confidence_level: expect.any(Number),
+                data_source: expect.any(String),
+                //TODO:
+              //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
+               polygon: {},
+               flex_schema_version: expect.any(String),
+               download_url: expect.any(String)
+                })
+            })
         })
 
         it('When passed without token, should return 401 status', async ()=>{
@@ -91,8 +112,29 @@ describe('GTFS Flex service', ()=>{
             expect(files.status).toBe(200);
 
             files.data.forEach(element => {
-                expect(element.tdei_service_id).toEqual(tdei_service_id);
-            });
+                expect(element).toMatchObject(<GtfsFlexDownload>{
+                    tdei_record_id: expect.any(String),
+                    tdei_org_id: expect.any(String),
+                    tdei_service_id: '801018f7-db32-4085-bbae-5339fa094cce',
+                    collected_by: expect.any(String),
+                    collection_date: expect.any(String),
+                collection_method: expect.any(String),
+                //TODO:
+                  //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
+                  valid_from: expect.any(String),
+                  valid_to: expect.any(String),
+                  //TODO:
+                //  confidence_level: expect.any(Number),
+                data_source: expect.any(String),
+                //TODO:
+              //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
+               polygon: {},
+               flex_schema_version: expect.any(String),
+               download_url: expect.any(String)
+                })
+            })
+
+          
         })
 
         it('When passed with valid token and valid recordId, should return 200 status with only single record with same record Id', async () => {
@@ -103,8 +145,29 @@ describe('GTFS Flex service', ()=>{
             const files = await flexApi.listFlexFiles(undefined,undefined,undefined,undefined,undefined,tdei_record_id);
 
             expect(files.status).toBe(200);
-            expect(files.data.length).toBe(1);
-            expect(files.data[0].tdei_record_id).toBe(tdei_record_id);
+            expect(files.data.length).toBe(1);        
+            files.data.forEach(element => {
+                expect(element).toMatchObject(<GtfsFlexDownload>{
+                    tdei_record_id: tdei_record_id,
+                    tdei_org_id: expect.any(String),
+                    tdei_service_id: expect.any(String),
+                    collected_by: expect.any(String),
+                    collection_date: expect.any(String),
+                collection_method: expect.any(String),
+                //TODO:
+                  //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
+                  valid_from: expect.any(String),
+                  valid_to: expect.any(String),
+                  //TODO:
+                //  confidence_level: expect.any(Number),
+                data_source: expect.any(String),
+                //TODO:
+              //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
+               polygon: {},
+               flex_schema_version: expect.any(String),
+               download_url: expect.any(String)
+                })
+            })
         })
 
         it('When passed with valid token and invalid recordId, should return 200 status with no records', async () => {
@@ -197,7 +260,13 @@ describe('GTFS Flex service', ()=>{
 
                 expect(services.status).toBe(200);
                 expect(Array.isArray(services.data)).toBe(true);
-
+                services.data.forEach(element => {
+                    expect(element).toMatchObject(<GtfsFlexServiceModel>{
+                        polygon: {},
+                        service_name: expect.any(String),
+                        tdei_service_id: expect.any(String)
+                    })
+                })
             });
 
             it('When passed with valid token and orgId, should return status 200 with list for same orgId', async ()=>{
@@ -255,6 +324,13 @@ describe('GTFS Flex service', ()=>{
 
                 expect(versions.status).toBe(200)
                 expect(Array.isArray(versions.data.versions)).toBe(true);
+                versions.data.versions?.forEach(version => {
+                    expect(version).toMatchObject(<VersionSpec>{
+                        version: expect.any(String),
+                        documentation: expect.any(String),
+                        specification: expect.any(String)
+                    })
+                })
             })
         })
         describe('Validation', () => {

--- a/src/__tests__/gtfspathways.test.ts
+++ b/src/__tests__/gtfspathways.test.ts
@@ -1,4 +1,4 @@
-import { GeneralApi, GTFSPathwaysApi, GtfsPathwaysUpload } from "tdei-client";
+import { GeneralApi, GtfsFlexDownload, GTFSPathwaysApi, GtfsPathwaysDownload, GtfsPathwaysUpload, Station, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import path from "path";
@@ -62,6 +62,24 @@ describe('GTFS Pathways service', () => {
         const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles();
 
         expect(Array.isArray(pathwayFiles.data)).toBe(true);
+        pathwayFiles.data.forEach(download => {
+          expect(download).toMatchObject(<GtfsPathwaysDownload>{
+            tdei_org_id: expect.any(String),
+            tdei_station_id: expect.any(String),
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            valid_from: expect.any(String),
+            valid_to: expect.any(String),
+            //TODO:
+           // confidence_level: expect.any(Number),
+           data_source: expect.any(String),
+           polygon: {},
+           tdei_record_id: expect.any(String),
+           pathways_schema_version: expect.any(String),
+           download_url: expect.any(String)
+          })
+        })
       })
 
       it('When passed with valid token and page size 5, should return list of files less than or equal to 5', async () => {
@@ -73,7 +91,24 @@ describe('GTFS Pathways service', () => {
 
         expect(pathwayFiles.status).toBe(200)
         expect(pathwayFiles.data.length).toBeLessThanOrEqual(page_size)
-
+        pathwayFiles.data.forEach(download => {
+          expect(download).toMatchObject(<GtfsPathwaysDownload>{
+            tdei_org_id: expect.any(String),
+            tdei_station_id: expect.any(String),
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            valid_from: expect.any(String),
+            valid_to: expect.any(String),
+            //TODO:
+           // confidence_level: expect.any(Number),
+           data_source: expect.any(String),
+           polygon: {},
+           tdei_record_id: expect.any(String),
+           pathways_schema_version: expect.any(String),
+           download_url: expect.any(String)
+          })
+        })
       })
 
       it('When passed with valid token and serviceId, should return list of files of same service id', async () =>{
@@ -85,10 +120,24 @@ describe('GTFS Pathways service', () => {
         const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM,stationId);
 
         expect(pathwayFiles.status).toBe(200);
-        pathwayFiles.data.forEach(element => {
-          expect(element.tdei_station_id).toEqual(stationId);
-        });
-
+        pathwayFiles.data.forEach(download => {
+          expect(download).toMatchObject(<GtfsPathwaysDownload>{
+            tdei_org_id: expect.any(String),
+            tdei_station_id: '5e20eb06-a950-4a5d-a9ca-1e390a801b8a',
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            valid_from: expect.any(String),
+            valid_to: expect.any(String),
+            //TODO:
+           // confidence_level: expect.any(Number),
+           data_source: expect.any(String),
+           polygon: {},
+           tdei_record_id: expect.any(String),
+           pathways_schema_version: expect.any(String),
+           download_url: expect.any(String)
+          })
+        })
       })
 
       it('When passed with valid token and recordId, should return record with same recordId', async () => {
@@ -100,10 +149,25 @@ describe('GTFS Pathways service', () => {
 
         expect(pathwayFiles.status).toBe(200);
         expect(pathwayFiles.data.length).toBe(1);
-        expect(pathwayFiles.data[0].tdei_record_id).toBe(recordId);
-
+        pathwayFiles.data.forEach(download => {
+          expect(download).toMatchObject(<GtfsPathwaysDownload>{
+            tdei_org_id: expect.any(String),
+            tdei_station_id: expect.any(String),
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            valid_from: expect.any(String),
+            valid_to: expect.any(String),
+            //TODO:
+           // confidence_level: expect.any(Number),
+           data_source: expect.any(String),
+           polygon: {},
+           tdei_record_id: '90d81b53e2e54abebd66986d2fdab169',
+           pathways_schema_version: expect.any(String),
+           download_url: expect.any(String)
+          })
+        })
       })
-
     })
 
     describe('Validation', ()=>{
@@ -208,7 +272,13 @@ describe('GTFS Pathways service', () => {
 
         expect(stations.status).toBe(200);
         expect(Array.isArray(stations.data)).toBe(true);
-        
+        stations.data.forEach(station => {
+          expect(station).toMatchObject(<Station>{
+            polygon: {},
+            station_name: expect.any(String),
+            tdei_station_id: expect.any(String)
+          })
+        })
       })
 
       it('When passed with valid token and orgId, should return the stations', async () =>{
@@ -218,6 +288,13 @@ describe('GTFS Pathways service', () => {
 
         expect(stations.status).toBe(200);
         expect(Array.isArray(stations.data)).toBe(true);
+        stations.data.forEach(station => {
+          expect(station).toMatchObject(<Station>{
+            polygon: {},
+            station_name: expect.any(String),
+            tdei_station_id: expect.any(String)
+          })
+        })
         
       })
 
@@ -264,6 +341,14 @@ describe('GTFS Pathways service', () => {
         let versions = await pathwaysAPI.listPathwaysVersions();
 
         expect(versions.status).toBe(200);
+        versions.data.versions?.forEach(version => {
+          expect(version).toMatchObject(<VersionSpec>{
+              version: expect.any(String),
+              documentation: expect.any(String),
+              specification: expect.any(String)
+          })
+      })
+
       })
     })
     describe('Validation', ()=>{

--- a/src/__tests__/gtfspathways.test.ts
+++ b/src/__tests__/gtfspathways.test.ts
@@ -124,7 +124,7 @@ describe('GTFS Pathways service', () => {
         pathwayFiles.data.forEach(download => {
           expect(download).toMatchObject(<GtfsPathwaysDownload>{
             tdei_org_id: expect.any(String),
-            tdei_station_id: '5e20eb06-a950-4a5d-a9ca-1e390a801b8a',
+            tdei_station_id: stationId,
             collected_by: expect.any(String),
             collection_date: expect.any(String),
             collection_method: expect.any(String),
@@ -163,7 +163,7 @@ describe('GTFS Pathways service', () => {
            // confidence_level: expect.any(Number),
            data_source: expect.any(String),
           polygon: expect.anything() as null | GeoJsonObject,
-           tdei_record_id: '90d81b53e2e54abebd66986d2fdab169',
+           tdei_record_id: recordId,
            pathways_schema_version: expect.any(String),
            download_url: expect.any(String)
           })

--- a/src/__tests__/gtfspathways.test.ts
+++ b/src/__tests__/gtfspathways.test.ts
@@ -1,10 +1,11 @@
-import { GeneralApi, GtfsFlexDownload, GTFSPathwaysApi, GtfsPathwaysDownload, GtfsPathwaysUpload, Station, VersionSpec } from "tdei-client";
+import { Feature, GeneralApi, GeoJsonObject, GtfsFlexDownload, GTFSPathwaysApi, GtfsPathwaysDownload, GtfsPathwaysUpload, Station, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import path from "path";
 import * as fs from "fs";
 import { Seeder } from "../seeder";
 import AdmZip from "adm-zip";
+import exp from "constants";
 
 const DOWNLOAD_FILE_PATH = `${__dirname}/tmp`;
 
@@ -74,7 +75,7 @@ describe('GTFS Pathways service', () => {
             //TODO:
            // confidence_level: expect.any(Number),
            data_source: expect.any(String),
-           polygon: {},
+          polygon: expect.anything() as null | GeoJsonObject,
            tdei_record_id: expect.any(String),
            pathways_schema_version: expect.any(String),
            download_url: expect.any(String)
@@ -103,7 +104,7 @@ describe('GTFS Pathways service', () => {
             //TODO:
            // confidence_level: expect.any(Number),
            data_source: expect.any(String),
-           polygon: {},
+          polygon: expect.anything() as null | GeoJsonObject,
            tdei_record_id: expect.any(String),
            pathways_schema_version: expect.any(String),
            download_url: expect.any(String)
@@ -132,7 +133,7 @@ describe('GTFS Pathways service', () => {
             //TODO:
            // confidence_level: expect.any(Number),
            data_source: expect.any(String),
-           polygon: {},
+          polygon: expect.anything() as null | GeoJsonObject,
            tdei_record_id: expect.any(String),
            pathways_schema_version: expect.any(String),
            download_url: expect.any(String)
@@ -161,7 +162,7 @@ describe('GTFS Pathways service', () => {
             //TODO:
            // confidence_level: expect.any(Number),
            data_source: expect.any(String),
-           polygon: {},
+          polygon: expect.anything() as null | GeoJsonObject,
            tdei_record_id: '90d81b53e2e54abebd66986d2fdab169',
            pathways_schema_version: expect.any(String),
            download_url: expect.any(String)
@@ -274,7 +275,7 @@ describe('GTFS Pathways service', () => {
         expect(Array.isArray(stations.data)).toBe(true);
         stations.data.forEach(station => {
           expect(station).toMatchObject(<Station>{
-            polygon: {},
+           polygon: expect.anything() as null | GeoJsonObject,
             station_name: expect.any(String),
             tdei_station_id: expect.any(String)
           })
@@ -290,7 +291,7 @@ describe('GTFS Pathways service', () => {
         expect(Array.isArray(stations.data)).toBe(true);
         stations.data.forEach(station => {
           expect(station).toMatchObject(<Station>{
-            polygon: {},
+           polygon: expect.anything() as null | GeoJsonObject,
             station_name: expect.any(String),
             tdei_station_id: expect.any(String)
           })

--- a/src/__tests__/osw.test.ts
+++ b/src/__tests__/osw.test.ts
@@ -1,4 +1,4 @@
-import { GeneralApi, OSWApi, OswUpload } from "tdei-client";
+import { GeneralApi, OSWApi, OswDownload, OswUpload, VersionSpec } from "tdei-client";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import { Utility } from "../utils";
 import path from "path";
@@ -56,6 +56,24 @@ describe('OSW service', () => {
 
         expect(oswFiles.status).toBe(200);
         expect(Array.isArray(oswFiles.data)).toBe(true);
+        oswFiles.data.forEach(file => {
+          expect(file).toMatchObject(<OswDownload>{
+            tdei_org_id: expect.any(String),
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            //TODO:
+           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+           //TODO:
+         // publication_date: expect.any(String),
+          // confidence_level: expect.any(String),
+          data_source: expect.any(String),
+          polygon: {},
+          tdei_record_id: expect.any(String),
+          osw_schema_version: expect.any(String),
+          download_url: expect.any(String)
+          })
+        })
       })
 
       it('When passed with valid token and page size, should return 200 status with files less than or equal to 5', async () =>{
@@ -66,6 +84,24 @@ describe('OSW service', () => {
 
         expect(oswFiles.status).toBe(200);
         expect(oswFiles.data.length).toBeLessThanOrEqual(page_size);
+        oswFiles.data.forEach(file => {
+          expect(file).toMatchObject(<OswDownload>{
+            tdei_org_id: expect.any(String),
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            //TODO:
+           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+           //TODO:
+         // publication_date: expect.any(String),
+          // confidence_level: expect.any(String),
+          data_source: expect.any(String),
+          polygon: {},
+          tdei_record_id: expect.any(String),
+          osw_schema_version: expect.any(String),
+          download_url: expect.any(String)
+          })
+        })
 
       })
 
@@ -77,9 +113,24 @@ describe('OSW service', () => {
         const oswFiles = await oswAPI.listOswFiles(NULL_PARAM,NULL_PARAM,orgId);
 
         expect(oswFiles.status).toBe(200);
-        oswFiles.data.forEach(element => {
-          expect(element.tdei_org_id).toEqual(orgId);
-        });
+        oswFiles.data.forEach(file => {
+          expect(file).toMatchObject(<OswDownload>{
+            tdei_org_id: '5e339544-3b12-40a5-8acd-78c66d1fa981',
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            //TODO:
+           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+           //TODO:
+         // publication_date: expect.any(String),
+          // confidence_level: expect.any(String),
+          data_source: expect.any(String),
+          polygon: {},
+          tdei_record_id: expect.any(String),
+          osw_schema_version: expect.any(String),
+          download_url: expect.any(String)
+          })
+        })
 
       })
 
@@ -92,7 +143,24 @@ describe('OSW service', () => {
 
         expect(oswFiles.status).toBe(200);
         expect(oswFiles.data.length).toBe(1);
-        expect(oswFiles.data[0].tdei_record_id).toBe(recordId);
+        oswFiles.data.forEach(file => {
+          expect(file).toMatchObject(<OswDownload>{
+            tdei_org_id: expect.any(String),
+            collected_by: expect.any(String),
+            collection_date: expect.any(String),
+            collection_method: expect.any(String),
+            //TODO:
+           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+           //TODO:
+         // publication_date: expect.any(String),
+          // confidence_level: expect.any(String),
+          data_source: expect.any(String),
+          polygon: {},
+          tdei_record_id: '978203eeac334bdeba262899fce1fd8a',
+          osw_schema_version: expect.any(String),
+          download_url: expect.any(String)
+          })
+        })
       })
 
     })
@@ -183,6 +251,15 @@ describe('OSW service', () => {
 
       expect(oswVersions.status).toBe(200);
       expect(Array.isArray(oswVersions.data.versions)).toBe(true);
+      oswVersions.data.versions?.forEach(version => {
+        expect(version).toMatchObject(<VersionSpec>{
+            version: expect.any(String),
+            documentation: expect.any(String),
+            specification: expect.any(String)
+        })
+    })
+      
+      
     })
 
     it('When passed without valid token, should respond with 401 status', async () =>{

--- a/src/__tests__/osw.test.ts
+++ b/src/__tests__/osw.test.ts
@@ -115,7 +115,7 @@ describe('OSW service', () => {
         expect(oswFiles.status).toBe(200);
         oswFiles.data.forEach(file => {
           expect(file).toMatchObject(<OswDownload>{
-            tdei_org_id: '5e339544-3b12-40a5-8acd-78c66d1fa981',
+            tdei_org_id: orgId,
             collected_by: expect.any(String),
             collection_date: expect.any(String),
             collection_method: expect.any(String),
@@ -156,7 +156,7 @@ describe('OSW service', () => {
           // confidence_level: expect.any(String),
           data_source: expect.any(String),
          polygon: expect.anything() as null | GeoJsonObject,
-          tdei_record_id: '978203eeac334bdeba262899fce1fd8a',
+          tdei_record_id: recordId,
           osw_schema_version: expect.any(String),
           download_url: expect.any(String)
           })

--- a/src/__tests__/osw.test.ts
+++ b/src/__tests__/osw.test.ts
@@ -1,4 +1,4 @@
-import { GeneralApi, OSWApi, OswDownload, OswUpload, VersionSpec } from "tdei-client";
+import { Feature, GeneralApi, GeoJsonObject, OSWApi, OswDownload, OswUpload, VersionSpec } from "tdei-client";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import { Utility } from "../utils";
 import path from "path";
@@ -68,7 +68,7 @@ describe('OSW service', () => {
          // publication_date: expect.any(String),
           // confidence_level: expect.any(String),
           data_source: expect.any(String),
-          polygon: {},
+         polygon: expect.anything() as null | GeoJsonObject,
           tdei_record_id: expect.any(String),
           osw_schema_version: expect.any(String),
           download_url: expect.any(String)
@@ -96,7 +96,7 @@ describe('OSW service', () => {
          // publication_date: expect.any(String),
           // confidence_level: expect.any(String),
           data_source: expect.any(String),
-          polygon: {},
+         polygon: expect.anything() as null | GeoJsonObject,
           tdei_record_id: expect.any(String),
           osw_schema_version: expect.any(String),
           download_url: expect.any(String)
@@ -125,7 +125,7 @@ describe('OSW service', () => {
          // publication_date: expect.any(String),
           // confidence_level: expect.any(String),
           data_source: expect.any(String),
-          polygon: {},
+         polygon: expect.anything() as null | GeoJsonObject,
           tdei_record_id: expect.any(String),
           osw_schema_version: expect.any(String),
           download_url: expect.any(String)
@@ -155,7 +155,7 @@ describe('OSW service', () => {
          // publication_date: expect.any(String),
           // confidence_level: expect.any(String),
           data_source: expect.any(String),
-          polygon: {},
+         polygon: expect.anything() as null | GeoJsonObject,
           tdei_record_id: '978203eeac334bdeba262899fce1fd8a',
           osw_schema_version: expect.any(String),
           download_url: expect.any(String)


### PR DESCRIPTION
Observations:

- Confidence_level value returned is null.

- Most of the test cases with value type of enums are failing. But tests are passing when expected is mentioned a String.

For these specific cases, keys are commented with a TODO comment. 