### PR TITLE
temp folder changes

### DIFF
--- a/src/__tests__/gtfsflex.test.ts
+++ b/src/__tests__/gtfsflex.test.ts
@@ -1,6 +1,6 @@
 
 
-import {  Feature, GeneralApi, GeoJsonObject, GeoJsonObjectTypeEnum, GTFSFlexApi, GtfsFlexDownload, GtfsFlexDownloadCollectionMethodEnum, GtfsFlexDownloadDataSourceEnum, GtfsFlexServiceModel, GtfsFlexUpload, VersionSpec } from "tdei-client";
+import { AuthenticationApi, Feature, GeneralApi, GeoJsonObject, GeoJsonObjectTypeEnum, GTFSFlexApi, GtfsFlexDownload, GtfsFlexDownloadCollectionMethodEnum, GtfsFlexDownloadDataSourceEnum, GtfsFlexServiceModel, GtfsFlexUpload, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import path from "path";
@@ -10,12 +10,12 @@ import { version } from "os";
 import AdmZip from "adm-zip";
 import exp from "constants";
 
-const DOWNLOAD_FILE_PATH = `${__dirname}/tmp`;
+const DOWNLOAD_FILE_PATH = `${__dirname}/gtfs-flex-tmp`;
 
-describe('GTFS Flex service', ()=>{
+describe('GTFS Flex service', () => {
     let configuration = Utility.getConfiguration();
     // Upload interceptor
-    const uploadRequestInterceptor = (request: InternalAxiosRequestConfig, fileName: string, metaToUpload:GtfsFlexUpload) => {
+    const uploadRequestInterceptor = (request: InternalAxiosRequestConfig, fileName: string, metaToUpload: GtfsFlexUpload) => {
         if (
             request.url === `${configuration.basePath}/api/v1/gtfs-flex`
         ) {
@@ -30,82 +30,82 @@ describe('GTFS Flex service', ()=>{
     };
 
     beforeAll(async () => {
-        let generalAPI = new GeneralApi(configuration);
-        const loginResponse = await generalAPI.authenticate({ username: configuration.username, password: configuration.password });
+        let authAPI = new AuthenticationApi(configuration);
+        const loginResponse = await authAPI.authenticate({ username: configuration.username, password: configuration.password });
         configuration.baseOptions = {
-          headers: {
-            ...Utility.addAuthZHeader(loginResponse.data.access_token)
-          }
+            headers: {
+                ...Utility.addAuthZHeader(loginResponse.data.access_token)
+            }
         };
         // Create a cleand up download folder
-    if (!fs.existsSync(DOWNLOAD_FILE_PATH)) {
-        fs.mkdirSync(DOWNLOAD_FILE_PATH)
-      } else {
-        fs.rmSync(DOWNLOAD_FILE_PATH, {recursive:true,force:true});
-        fs.mkdirSync(DOWNLOAD_FILE_PATH);
-      }
+        if (!fs.existsSync(DOWNLOAD_FILE_PATH)) {
+            fs.mkdirSync(DOWNLOAD_FILE_PATH)
+        } else {
+            fs.rmSync(DOWNLOAD_FILE_PATH, { recursive: true, force: true });
+            fs.mkdirSync(DOWNLOAD_FILE_PATH);
+        }
     });
 
-    afterAll(async ()=>{
-        fs.rmSync(DOWNLOAD_FILE_PATH, {recursive:true,force:true});
+    afterAll(async () => {
+        fs.rmSync(DOWNLOAD_FILE_PATH, { recursive: true, force: true });
     })
-    describe('List Files', ()=>{
-        it('When passed with valid token, should return 200 status with files list', async () =>{
-            
+    describe('List Files', () => {
+        it('When passed with valid token, should return 200 status with files list', async () => {
+
             let gtfsFlexAPI = new GTFSFlexApi(configuration);
-            
+
             const filesResponse = await gtfsFlexAPI.listFlexFiles();
 
             expect(filesResponse.status).toBe(200)
             expect(Array.isArray(filesResponse.data)).toBe(true);
             filesResponse.data.forEach(element => {
-               expectPolygon(element.polygon);
+                expectPolygon(element.polygon);
                 expect(element).toMatchObject(<GtfsFlexDownload>{
                     tdei_record_id: expect.any(String),
                     tdei_org_id: expect.any(String),
                     tdei_service_id: expect.any(String),
                     collected_by: expect.any(String),
                     collection_date: expect.any(String),
-                collection_method: expect.any(String),
-                //TODO:
-                  //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
-                  valid_from: expect.any(String),
-                  valid_to: expect.any(String),
-                  //TODO:
-                //  confidence_level: expect.any(Number),
-                data_source: expect.any(String),
-                //TODO:
-              //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
-               polygon: expect.any(Object || null),
-               flex_schema_version: expect.any(String),
-               download_url: expect.any(String)
+                    collection_method: expect.any(String),
+                    //TODO:
+                    //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
+                    valid_from: expect.any(String),
+                    valid_to: expect.any(String),
+                    //TODO:
+                    //  confidence_level: expect.any(Number),
+                    data_source: expect.any(String),
+                    //TODO:
+                    //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
+                    polygon: expect.any(Object || null),
+                    flex_schema_version: expect.any(String),
+                    download_url: expect.any(String)
                 })
             })
         })
 
-        it('When passed without token, should return 401 status', async ()=>{
-            
+        it('When passed without token, should return 401 status', async () => {
+
             let flexApi = new GTFSFlexApi(Utility.getConfiguration());
 
             const filesPromise = flexApi.listFlexFiles();
 
-            await expect(filesPromise).rejects.toMatchObject({response:{status:401}})
+            await expect(filesPromise).rejects.toMatchObject({ response: { status: 401 } })
 
         })
 
-        it('When passed with token and page_size 5, should return 200 status with less than 5 elements', async ()=>{
-            
+        it('When passed with token and page_size 5, should return 200 status with less than 5 elements', async () => {
+
             let flexApi = new GTFSFlexApi(configuration);
 
-            const files = await flexApi.listFlexFiles(undefined,undefined,undefined,undefined,undefined,undefined,undefined,5);
+            const files = await flexApi.listFlexFiles(undefined, undefined, undefined, undefined, undefined, undefined, undefined, 5);
 
             expect(files.status).toBe(200);
             expect(files.data.length).toBeLessThanOrEqual(5);
 
         })
 
-        it('When passed with valid token and tdei_service_id, shold return records of same service', async ()=>{
-            
+        it('When passed with valid token and tdei_service_id, shold return records of same service', async () => {
+
             let tdei_service_id = '801018f7-db32-4085-bbae-5339fa094cce';
             let flexApi = new GTFSFlexApi(configuration);
 
@@ -121,34 +121,34 @@ describe('GTFS Flex service', ()=>{
                     tdei_service_id: tdei_service_id,
                     collected_by: expect.any(String),
                     collection_date: expect.any(String),
-                collection_method: expect.any(String),
-                //TODO:
-                  //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
-                  valid_from: expect.any(String),
-                  valid_to: expect.any(String),
-                  //TODO:
-                //  confidence_level: expect.any(Number),
-                data_source: expect.any(String),
-                //TODO:
-              //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
-              polygon: expect.any(Object || null),
-               flex_schema_version: expect.any(String),
-               download_url: expect.any(String)
+                    collection_method: expect.any(String),
+                    //TODO:
+                    //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
+                    valid_from: expect.any(String),
+                    valid_to: expect.any(String),
+                    //TODO:
+                    //  confidence_level: expect.any(Number),
+                    data_source: expect.any(String),
+                    //TODO:
+                    //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
+                    polygon: expect.any(Object || null),
+                    flex_schema_version: expect.any(String),
+                    download_url: expect.any(String)
                 })
             })
 
-          
+
         })
 
         it('When passed with valid token and valid recordId, should return 200 status with only single record with same record Id', async () => {
-           
+
             let tdei_record_id = '2bf7f70127b146cbb96319b5d39ada93';
             let flexApi = new GTFSFlexApi(configuration);
 
-            const files = await flexApi.listFlexFiles(undefined,undefined,undefined,undefined,undefined,tdei_record_id);
+            const files = await flexApi.listFlexFiles(undefined, undefined, undefined, undefined, undefined, tdei_record_id);
 
             expect(files.status).toBe(200);
-            expect(files.data.length).toBe(1);        
+            expect(files.data.length).toBe(1);
             files.data.forEach(element => {
                 expectPolygon(element.polygon);
                 expect(element).toMatchObject(<GtfsFlexDownload>{
@@ -157,19 +157,19 @@ describe('GTFS Flex service', ()=>{
                     tdei_service_id: expect.any(String),
                     collected_by: expect.any(String),
                     collection_date: expect.any(String),
-                collection_method: expect.any(String),
-                //TODO:
-                  //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
-                  valid_from: expect.any(String),
-                  valid_to: expect.any(String),
-                  //TODO:
-                //  confidence_level: expect.any(Number),
-                data_source: expect.any(String),
-                //TODO:
-              //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
-              polygon: expect.any(Object || null),
-               flex_schema_version: expect.any(String),
-               download_url: expect.any(String)
+                    collection_method: expect.any(String),
+                    //TODO:
+                    //  collection_method: expect.any(GtfsFlexDownloadCollectionMethodEnum),
+                    valid_from: expect.any(String),
+                    valid_to: expect.any(String),
+                    //TODO:
+                    //  confidence_level: expect.any(Number),
+                    data_source: expect.any(String),
+                    //TODO:
+                    //  data_source: expect.any(GtfsFlexDownloadDataSourceEnum),
+                    polygon: expect.any(Object || null),
+                    flex_schema_version: expect.any(String),
+                    download_url: expect.any(String)
                 })
             })
         })
@@ -179,7 +179,7 @@ describe('GTFS Flex service', ()=>{
             let tdei_record_id = 'randomrecordid';
             let flexApi = new GTFSFlexApi(configuration);
 
-            const files = await flexApi.listFlexFiles(undefined,undefined,undefined,undefined,undefined,tdei_record_id);
+            const files = await flexApi.listFlexFiles(undefined, undefined, undefined, undefined, undefined, tdei_record_id);
 
             expect(files.status).toBe(200);
             expect(files.data.length).toBe(0);
@@ -191,75 +191,75 @@ describe('GTFS Flex service', ()=>{
 
         var serviceId: string = '';
 
-        beforeAll( async ()=>{
+        beforeAll(async () => {
             const seeder = new Seeder();
             serviceId = await seeder.createService('c552d5d1-0719-4647-b86d-6ae9b25327b7');
             seeder.removeHeader();
 
         })
 
-        describe('Functional', ()=> {
+        describe('Functional', () => {
 
             it('When passed with valid token, metadata and file, should return 202 status with recordId', async () => {
 
                 //TODO: Simplify this arrange.
                 let flexApi = new GTFSFlexApi(configuration);
-                const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "flex-test-upload.zip",metaToUpload))
+                const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "flex-test-upload.zip", metaToUpload))
                 let metaToUpload = Utility.getRandomGtfsFlexUpload();
                 metaToUpload.tdei_service_id = serviceId;
                 metaToUpload.tdei_org_id = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
                 let fileBlob = Utility.getFlexBlob();
-                
-                const uploadedFileResponse = await flexApi.uploadGtfsFlexFileForm(metaToUpload,fileBlob);
-                
+
+                const uploadedFileResponse = await flexApi.uploadGtfsFlexFileForm(metaToUpload, fileBlob);
+
                 expect(uploadedFileResponse.status).toBe(202);
                 expect(uploadedFileResponse.data != "").toBe(true);
-            
-                axios.interceptors.request.eject(uploadInterceptor);
-            },20000)
 
-            it('When passed with valid token, invalid metadata and correct file, should return 400 status', async ()=>{
-                
+                axios.interceptors.request.eject(uploadInterceptor);
+            }, 20000)
+
+            it('When passed with valid token, invalid metadata and correct file, should return 400 status', async () => {
+
                 let flexApi = new GTFSFlexApi(configuration);
-                const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "flex-test-upload.zip",metaToUpload))
+                const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "flex-test-upload.zip", metaToUpload))
                 let metaToUpload = Utility.getRandomGtfsFlexUpload();
                 metaToUpload.tdei_org_id = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
-                metaToUpload.flex_schema_version = "0.0";
+                metaToUpload.data_source = <any>"Test";
                 let fileBlob = Utility.getFlexBlob();
-                
-                const uploadedFileResponse = flexApi.uploadGtfsFlexFileForm(metaToUpload,fileBlob);
 
-                await expect(uploadedFileResponse).rejects.toMatchObject({response:{status:400}});
-            
+                const uploadedFileResponse = flexApi.uploadGtfsFlexFileForm(metaToUpload, fileBlob);
+
+                await expect(uploadedFileResponse).rejects.toMatchObject({ response: { status: 400 } });
+
                 axios.interceptors.request.eject(uploadInterceptor);
 
-            },12000)
+            }, 12000)
 
-            it('When passed with invalid token, valid metadata and valid file, should return 401 status', async () =>{
-                
+            it('When passed with invalid token, valid metadata and valid file, should return 401 status', async () => {
+
                 let flexApi = new GTFSFlexApi(Utility.getConfiguration());
-                const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "flex-test-upload.zip",metaToUpload))
+                const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "flex-test-upload.zip", metaToUpload))
                 let metaToUpload = Utility.getRandomGtfsFlexUpload();
                 metaToUpload.tdei_service_id = serviceId;
                 metaToUpload.tdei_org_id = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
                 let fileBlob = Utility.getFlexBlob();
 
-                const uploadedFileResponse =  flexApi.uploadGtfsFlexFileForm(metaToUpload,fileBlob);
+                const uploadedFileResponse = flexApi.uploadGtfsFlexFileForm(metaToUpload, fileBlob);
 
-                await expect(uploadedFileResponse).rejects.toMatchObject({response:{status:401}});
-            
+                await expect(uploadedFileResponse).rejects.toMatchObject({ response: { status: 401 } });
+
                 axios.interceptors.request.eject(uploadInterceptor);
-            },18000)
+            }, 18000)
         })
     })
 
-    describe('List services', ()=>{
-        
-        describe('Functional', ()=>{
-            it('When passed with valid token, should return status 200 with list of services', async ()=>{
-                
+    describe('List services', () => {
+
+        describe('Functional', () => {
+            it('When passed with valid token, should return status 200 with list of services', async () => {
+
                 let flexApi = new GTFSFlexApi(configuration);
-                
+
                 const services = await flexApi.listFlexServices();
 
                 expect(services.status).toBe(200);
@@ -267,62 +267,62 @@ describe('GTFS Flex service', ()=>{
                 services.data.forEach(element => {
                     expectPolygon(element.polygon);
                     expect(element).toMatchObject(<GtfsFlexServiceModel>{
-                       polygon: expect.any(Object || null),
+                        polygon: expect.any(Object || null),
                         service_name: expect.any(String),
                         tdei_service_id: expect.any(String)
                     })
                 })
             });
 
-            it('When passed with valid token and orgId, should return status 200 with list for same orgId', async ()=>{
-                
+            it('When passed with valid token and orgId, should return status 200 with list for same orgId', async () => {
+
                 let orgId = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
                 let flexApi = new GTFSFlexApi(configuration);
-                
+
                 const services = await flexApi.listFlexServices(orgId);
 
                 expect(services.status).toBe(200);
                 expect(Array.isArray(services.data)).toBe(true);
             });
 
-            it('When passed with valid token and invalid orgId, should return status 200 with empty list', async ()=>{
-                
+            it('When passed with valid token and invalid orgId, should return status 200 with empty list', async () => {
+
                 let orgId = 'dummyOrgId';
                 let flexApi = new GTFSFlexApi(configuration);
-                
+
                 const services = await flexApi.listFlexServices(orgId);
 
                 expect(services.status).toBe(200);
                 expect(services.data.length).toBe(0);
             });
 
-            it('When passed with valid token and page limit, should return status 200 with list less than or equal', async ()=>{
+            it('When passed with valid token and page limit, should return status 200 with list less than or equal', async () => {
                 let page_size = 5;
                 let flexApi = new GTFSFlexApi(configuration);
-                
-                const services = await flexApi.listFlexServices(undefined,undefined,page_size);
+
+                const services = await flexApi.listFlexServices(undefined, undefined, page_size);
 
                 expect(services.status).toBe(200);
                 expect(Array.isArray(services.data)).toBe(true);
                 expect(services.data.length).toBeLessThanOrEqual(page_size);
             });
 
-            it('When passed with invalid token, should return 401 status', async ()=>{
+            it('When passed with invalid token, should return 401 status', async () => {
 
                 let flexApi = new GTFSFlexApi(Utility.getConfiguration());
-                
-                const services =  flexApi.listFlexServices();
 
-                await expect(services).rejects.toMatchObject({response:{status:401}});
+                const services = flexApi.listFlexServices();
+
+                await expect(services).rejects.toMatchObject({ response: { status: 401 } });
             });
 
 
         })
     })
 
-    describe('List Flex versions', ()=>{
-        describe('Functional', ()=>{
-            it('When passed with valid token, should return 200 status with versions', async () =>{
+    describe('List Flex versions', () => {
+        describe('Functional', () => {
+            it('When passed with valid token, should return 200 status with versions', async () => {
                 let flexApi = new GTFSFlexApi(configuration);
 
                 const versions = await flexApi.listFlexVersions();
@@ -339,69 +339,69 @@ describe('GTFS Flex service', ()=>{
             })
         })
         describe('Validation', () => {
-            it('When passed with invalid token, should return 401 status', async ()=>{
+            it('When passed with invalid token, should return 401 status', async () => {
                 let flexApi = new GTFSFlexApi(Utility.getConfiguration());
 
                 const versions = flexApi.listFlexVersions();
 
-                await expect(versions).rejects.toMatchObject({response:{status:401}});
+                await expect(versions).rejects.toMatchObject({ response: { status: 401 } });
             })
         })
     })
 
-    describe('Get a record for Flex', ()=>{
+    describe('Get a record for Flex', () => {
         describe('Functional', () => {
-          it('When passed with valid recordId, should be able to get the zip file', async ()=>{
-            
-            let flexRecordId = '8c6c92c8cb38415e9e2775733a4bf52e';
-            let flexAPI = new GTFSFlexApi(configuration);
-    
-            let response = await flexAPI.getFlexFile(flexRecordId,{responseType:'arraybuffer'});
-            const data: any = response.data;
-            const contentDisposition = response.headers['content-disposition'];
-            const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-            const matches = filenameRegex.exec(contentDisposition);
-            const fileName = (matches != null && matches[1]) ? matches[1].replace(/['"]/g, '') : 'data.zip';
-            const filePath = `${DOWNLOAD_FILE_PATH}/${fileName}`
-            fs.writeFileSync(filePath, new Uint8Array(data))
-            const zip = new AdmZip(filePath);
-            const entries = zip.getEntries();
-    
-            expect(entries.length).toBeGreaterThan(0);
-            expect(fileName.includes('zip')).toBe(true);
-            expect(response.data).not.toBeNull();
-            expect(response.status).toBe(200);
-    
-          })
-    
+            it('When passed with valid recordId, should be able to get the zip file', async () => {
+
+                let flexRecordId = '8c6c92c8cb38415e9e2775733a4bf52e';
+                let flexAPI = new GTFSFlexApi(configuration);
+
+                let response = await flexAPI.getFlexFile(flexRecordId, { responseType: 'arraybuffer' });
+                const data: any = response.data;
+                const contentDisposition = response.headers['content-disposition'];
+                const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                const matches = filenameRegex.exec(contentDisposition);
+                const fileName = (matches != null && matches[1]) ? matches[1].replace(/['"]/g, '') : 'data.zip';
+                const filePath = `${DOWNLOAD_FILE_PATH}/${fileName}`
+                fs.writeFileSync(filePath, new Uint8Array(data))
+                const zip = new AdmZip(filePath);
+                const entries = zip.getEntries();
+
+                expect(entries.length).toBeGreaterThan(0);
+                expect(fileName.includes('zip')).toBe(true);
+                expect(response.data).not.toBeNull();
+                expect(response.status).toBe(200);
+
+            })
+
         })
-    
-        describe('Validation', ()=>{
-          it('When passed with valid recordId and invalid token, should return 401 status', async ()=>{
-    
-            let flexRecordId = '8c6c92c8cb38415e9e2775733a4bf52e';
-            let flexAPI = new GTFSFlexApi(Utility.getConfiguration());
-    
-            let response = flexAPI.getFlexFile(flexRecordId);
-    
-            await expect(response).rejects.toMatchObject({response:{status:401}});
-    
-          })
-    
-          it('When passed with invalid record and valid token, should return 404 status', async () =>{
-    
-            let flexRecordId = 'dummyRecordId';
-            let flexAPI = new GTFSFlexApi(configuration);
-    
-            let response = flexAPI.getFlexFile(flexRecordId);
-    
-            await expect(response).rejects.toMatchObject({response:{status:404}});
-    
-          })
-    
+
+        describe('Validation', () => {
+            it('When passed with valid recordId and invalid token, should return 401 status', async () => {
+
+                let flexRecordId = '8c6c92c8cb38415e9e2775733a4bf52e';
+                let flexAPI = new GTFSFlexApi(Utility.getConfiguration());
+
+                let response = flexAPI.getFlexFile(flexRecordId);
+
+                await expect(response).rejects.toMatchObject({ response: { status: 401 } });
+
+            })
+
+            it('When passed with invalid record and valid token, should return 404 status', async () => {
+
+                let flexRecordId = 'dummyRecordId';
+                let flexAPI = new GTFSFlexApi(configuration);
+
+                let response = flexAPI.getFlexFile(flexRecordId);
+
+                await expect(response).rejects.toMatchObject({ response: { status: 404 } });
+
+            })
+
         })
-        
-      })
+
+    })
 
 })
 

--- a/src/__tests__/gtfspathways.test.ts
+++ b/src/__tests__/gtfspathways.test.ts
@@ -1,4 +1,4 @@
-import { Feature, GeneralApi, GeoJsonObject, GtfsFlexDownload, GTFSPathwaysApi, GtfsPathwaysDownload, GtfsPathwaysUpload, Station, VersionSpec } from "tdei-client";
+import { AuthenticationApi, Feature, GeneralApi, GeoJsonObject, GtfsFlexDownload, GTFSPathwaysApi, GtfsPathwaysDownload, GtfsPathwaysUpload, Station, VersionSpec } from "tdei-client";
 import { Utility } from "../utils";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import path from "path";
@@ -7,7 +7,7 @@ import { Seeder } from "../seeder";
 import AdmZip from "adm-zip";
 import exp from "constants";
 
-const DOWNLOAD_FILE_PATH = `${__dirname}/tmp`;
+const DOWNLOAD_FILE_PATH = `${__dirname}/gtfs-pathways-tmp`;
 
 describe('GTFS Pathways service', () => {
 
@@ -15,23 +15,23 @@ describe('GTFS Pathways service', () => {
   const NULL_PARAM = void 0;
 
 
-  const uploadRequestInterceptor = (request: InternalAxiosRequestConfig, fileName: string, metaToUpload:GtfsPathwaysUpload) => {
+  const uploadRequestInterceptor = (request: InternalAxiosRequestConfig, fileName: string, metaToUpload: GtfsPathwaysUpload) => {
     if (
-        request.url === `${configuration.basePath}/api/v1/gtfs-pathways`
+      request.url === `${configuration.basePath}/api/v1/gtfs-pathways`
     ) {
-        let data = request.data as FormData;
-        let file = data.get("file") as File;
-        delete data["file"];
-        delete data["meta"];
-        data.set("file", file, fileName);
-        data.set("meta", JSON.stringify(metaToUpload));
+      let data = request.data as FormData;
+      let file = data.get("file") as File;
+      delete data["file"];
+      delete data["meta"];
+      data.set("file", file, fileName);
+      data.set("meta", JSON.stringify(metaToUpload));
     }
     return request;
-};
+  };
 
   beforeAll(async () => {
-    let generalAPI = new GeneralApi(configuration);
-    const loginResponse = await generalAPI.authenticate({
+    let authAPI = new AuthenticationApi(configuration);
+    const loginResponse = await authAPI.authenticate({
       username: configuration.username,
       password: configuration.password
     });
@@ -42,14 +42,14 @@ describe('GTFS Pathways service', () => {
     if (!fs.existsSync(DOWNLOAD_FILE_PATH)) {
       fs.mkdirSync(DOWNLOAD_FILE_PATH)
     } else {
-      fs.rmSync(DOWNLOAD_FILE_PATH, {recursive:true,force:true});
+      fs.rmSync(DOWNLOAD_FILE_PATH, { recursive: true, force: true });
       fs.mkdirSync(DOWNLOAD_FILE_PATH);
     }
 
   });
 
-  afterAll(async ()=>{
-    fs.rmSync(DOWNLOAD_FILE_PATH, {recursive:true,force:true});
+  afterAll(async () => {
+    fs.rmSync(DOWNLOAD_FILE_PATH, { recursive: true, force: true });
   })
 
   describe('List files ', () => {
@@ -74,12 +74,12 @@ describe('GTFS Pathways service', () => {
             valid_from: expect.any(String),
             valid_to: expect.any(String),
             //TODO:
-           // confidence_level: expect.any(Number),
-           data_source: expect.any(String),
-          polygon: expect.any(Object || null),
-           tdei_record_id: expect.any(String),
-           pathways_schema_version: expect.any(String),
-           download_url: expect.any(String)
+            // confidence_level: expect.any(Number),
+            data_source: expect.any(String),
+            polygon: expect.any(Object || null),
+            tdei_record_id: expect.any(String),
+            pathways_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
       })
@@ -89,7 +89,7 @@ describe('GTFS Pathways service', () => {
         let gtfsPathwaysAPI = new GTFSPathwaysApi(configuration);
         let page_size = 5
 
-        const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,page_size);
+        const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, page_size);
 
         expect(pathwayFiles.status).toBe(200)
         expect(pathwayFiles.data.length).toBeLessThanOrEqual(page_size)
@@ -104,23 +104,23 @@ describe('GTFS Pathways service', () => {
             valid_from: expect.any(String),
             valid_to: expect.any(String),
             //TODO:
-           // confidence_level: expect.any(Number),
-           data_source: expect.any(String),
-          polygon: expect.any(Object || null),
-           tdei_record_id: expect.any(String),
-           pathways_schema_version: expect.any(String),
-           download_url: expect.any(String)
+            // confidence_level: expect.any(Number),
+            data_source: expect.any(String),
+            polygon: expect.any(Object || null),
+            tdei_record_id: expect.any(String),
+            pathways_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
       })
 
-      it('When passed with valid token and serviceId, should return list of files of same service id', async () =>{
+      it('When passed with valid token and serviceId, should return list of files of same service id', async () => {
 
         let gtfsPathwaysAPI = new GTFSPathwaysApi(configuration);
         //TODO: feed from seeder or configuration
         let stationId = '5e20eb06-a950-4a5d-a9ca-1e390a801b8a';
 
-        const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM,stationId);
+        const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM, stationId);
 
         expect(pathwayFiles.status).toBe(200);
         pathwayFiles.data.forEach(download => {
@@ -134,12 +134,12 @@ describe('GTFS Pathways service', () => {
             valid_from: expect.any(String),
             valid_to: expect.any(String),
             //TODO:
-           // confidence_level: expect.any(Number),
-           data_source: expect.any(String),
-          polygon: expect.any(Object || null),
-           tdei_record_id: expect.any(String),
-           pathways_schema_version: expect.any(String),
-           download_url: expect.any(String)
+            // confidence_level: expect.any(Number),
+            data_source: expect.any(String),
+            polygon: expect.any(Object || null),
+            tdei_record_id: expect.any(String),
+            pathways_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
       })
@@ -149,12 +149,12 @@ describe('GTFS Pathways service', () => {
         let recordId = '90d81b53e2e54abebd66986d2fdab169';
         let gtfsPathwaysAPI = new GTFSPathwaysApi(configuration);
 
-        const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,recordId);
+        const pathwayFiles = await gtfsPathwaysAPI.listPathwaysFiles(NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, recordId);
 
         expect(pathwayFiles.status).toBe(200);
         expect(pathwayFiles.data.length).toBe(1);
         pathwayFiles.data.forEach(download => {
-          expectPolygon(download.polygon); 
+          expectPolygon(download.polygon);
           expect(download).toMatchObject(<GtfsPathwaysDownload>{
             tdei_org_id: expect.any(String),
             tdei_station_id: expect.any(String),
@@ -164,18 +164,18 @@ describe('GTFS Pathways service', () => {
             valid_from: expect.any(String),
             valid_to: expect.any(String),
             //TODO:
-           // confidence_level: expect.any(Number),
-           data_source: expect.any(String),
-          polygon: expect.any(Object || null),
-           tdei_record_id: recordId,
-           pathways_schema_version: expect.any(String),
-           download_url: expect.any(String)
+            // confidence_level: expect.any(Number),
+            data_source: expect.any(String),
+            polygon: expect.any(Object || null),
+            tdei_record_id: recordId,
+            pathways_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
       })
     })
 
-    describe('Validation', ()=>{
+    describe('Validation', () => {
 
       it('When passed without token, should return 401 status', async () => {
 
@@ -183,15 +183,15 @@ describe('GTFS Pathways service', () => {
 
         const pathwaysResponse = pathwaysAPI.listPathwaysFiles();
 
-        await expect(pathwaysResponse).rejects.toMatchObject({response:{status:401}});
+        await expect(pathwaysResponse).rejects.toMatchObject({ response: { status: 401 } });
 
       })
 
-      it('When passed with valid token and invalid recordId, should return 200 status with no elements', async () =>{
+      it('When passed with valid token and invalid recordId, should return 200 status with no elements', async () => {
         let dummyRecordId = 'dummyRecordId';
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
-        const pathwaysResponse = await pathwaysAPI.listPathwaysFiles(undefined,undefined,undefined,undefined,undefined,dummyRecordId);
+        const pathwaysResponse = await pathwaysAPI.listPathwaysFiles(undefined, undefined, undefined, undefined, undefined, dummyRecordId);
 
         expect(pathwaysResponse.status).toBe(200);
         expect(pathwaysResponse.data.length).toBe(0);
@@ -200,75 +200,75 @@ describe('GTFS Pathways service', () => {
 
   })
 
-  describe('Post Pathway File', ()=>{
+  describe('Post Pathway File', () => {
     var stationId: string = '';
     //TODO: feed from seeder or configuration
     const orgId = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
 
-    beforeAll( async ()=>{
-        const seeder = new Seeder();
-        stationId = await seeder.createStation(orgId);
-        seeder.removeHeader();
+    beforeAll(async () => {
+      const seeder = new Seeder();
+      stationId = await seeder.createStation(orgId);
+      seeder.removeHeader();
     })
 
-    describe('Functional', ()=>{
+    describe('Functional', () => {
 
-      it('When passed with valid token, metadata and file, should return 202 with recordId', async () =>{
+      it('When passed with valid token, metadata and file, should return 202 with recordId', async () => {
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
         let metaToUpload = Utility.getRandomPathwaysUpload();
-        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "pathways-test-upload.zip",metaToUpload))
+        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "pathways-test-upload.zip", metaToUpload))
         metaToUpload.tdei_org_id = orgId;
         metaToUpload.tdei_station_id = stationId;
         let fileBlob = Utility.getPathwaysBlob();
 
-        const uploadedFileResponse = await pathwaysAPI.uploadPathwaysFileForm(metaToUpload,fileBlob);
-                
+        const uploadedFileResponse = await pathwaysAPI.uploadPathwaysFileForm(metaToUpload, fileBlob);
+
         expect(uploadedFileResponse.status).toBe(202);
         expect(uploadedFileResponse.data != "").toBe(true);
-    
+
         axios.interceptors.request.eject(uploadInterceptor);
 
-      },20000)
+      }, 20000)
 
       it('When passed with valid token, file and invalid metadata, should return 400 status', async () => {
 
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
         let metaToUpload = Utility.getRandomPathwaysUpload();
-        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "pathways-test-upload.zip",metaToUpload))
+        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "pathways-test-upload.zip", metaToUpload))
         metaToUpload.tdei_org_id = orgId;
         metaToUpload.tdei_station_id = stationId;
         metaToUpload.collection_date = "";
         let fileBlob = Utility.getPathwaysBlob();
 
-        const uploadedFileResponse =  pathwaysAPI.uploadPathwaysFileForm(metaToUpload,fileBlob);
-                
-        await expect(uploadedFileResponse).rejects.toMatchObject({response:{status:400}});
-    
-        axios.interceptors.request.eject(uploadInterceptor);
-      },20000)
+        const uploadedFileResponse = pathwaysAPI.uploadPathwaysFileForm(metaToUpload, fileBlob);
 
-      it('When passed with invalid token, valid metadata and file, should return 401 status', async ()=>{
+        await expect(uploadedFileResponse).rejects.toMatchObject({ response: { status: 400 } });
+
+        axios.interceptors.request.eject(uploadInterceptor);
+      }, 20000)
+
+      it('When passed with invalid token, valid metadata and file, should return 401 status', async () => {
 
         let pathwaysAPI = new GTFSPathwaysApi(Utility.getConfiguration());
         let metaToUpload = Utility.getRandomPathwaysUpload();
-        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "pathways-test-upload.zip",metaToUpload))
+        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "pathways-test-upload.zip", metaToUpload))
         metaToUpload.tdei_org_id = orgId;
         metaToUpload.tdei_station_id = stationId;
         let fileBlob = Utility.getPathwaysBlob();
 
-        const uploadedFileResponse = pathwaysAPI.uploadPathwaysFileForm(metaToUpload,fileBlob);
+        const uploadedFileResponse = pathwaysAPI.uploadPathwaysFileForm(metaToUpload, fileBlob);
 
-        await expect(uploadedFileResponse).rejects.toMatchObject({response:{status:401}});
-    
+        await expect(uploadedFileResponse).rejects.toMatchObject({ response: { status: 401 } });
+
         axios.interceptors.request.eject(uploadInterceptor);
       })
     })
   })
 
-  describe('List stations', ()=>{
+  describe('List stations', () => {
     //TODO: feed from seeder or configuration
     const orgId = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
-    describe('Functional', ()=>{
+    describe('Functional', () => {
 
       it('When passed with valid token, should return return 200 status with list of stations', async () => {
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
@@ -280,14 +280,14 @@ describe('GTFS Pathways service', () => {
         stations.data.forEach(station => {
           expectPolygon(station.polygon);
           expect(station).toMatchObject(<Station>{
-           polygon: expect.any(Object || null),
+            polygon: expect.any(Object || null),
             station_name: expect.any(String),
             tdei_station_id: expect.any(String)
           })
         })
       })
 
-      it('When passed with valid token and orgId, should return the stations', async () =>{
+      it('When passed with valid token and orgId, should return the stations', async () => {
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
         let stations = await pathwaysAPI.listStations(orgId);
@@ -297,36 +297,36 @@ describe('GTFS Pathways service', () => {
         stations.data.forEach(station => {
           expectPolygon(station.polygon);
           expect(station).toMatchObject(<Station>{
-           polygon: expect.any(Object || null),
+            polygon: expect.any(Object || null),
             station_name: expect.any(String),
             tdei_station_id: expect.any(String)
           })
         })
-        
+
       })
 
-      it('When passed with valid token and page limit, should return less than or equal to number of stations', async ()=>{
+      it('When passed with valid token and page limit, should return less than or equal to number of stations', async () => {
         let page_size = 5;
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
-        let stations = await pathwaysAPI.listStations(undefined,undefined,page_size);
+        let stations = await pathwaysAPI.listStations(undefined, undefined, page_size);
 
         expect(stations.status).toBe(200);
         expect(stations.data.length).toBeLessThanOrEqual(page_size);
       })
 
     })
-    describe('Validation', ()=>{
+    describe('Validation', () => {
 
-      it('When passed with invalid token, should return 401 status', async () =>{
+      it('When passed with invalid token, should return 401 status', async () => {
         let pathwaysAPI = new GTFSPathwaysApi(Utility.getConfiguration());
 
         let stations = pathwaysAPI.listStations();
 
-        await expect(stations).rejects.toMatchObject({response:{status:401}});
+        await expect(stations).rejects.toMatchObject({ response: { status: 401 } });
       })
 
-      it('When passed with valid token and invalid orgId, should return 200 status with 0 stations', async () =>{
+      it('When passed with valid token and invalid orgId, should return 200 status with 0 stations', async () => {
         let orgId = "dummyOrgID";
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
@@ -341,8 +341,8 @@ describe('GTFS Pathways service', () => {
   })
 
   describe('Pathways versions', () => {
-    describe('Functional', ()=>{
-      it('When passed with valid token, should return 200 status with versions list', async () =>{
+    describe('Functional', () => {
+      it('When passed with valid token, should return 200 status with versions list', async () => {
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
         let versions = await pathwaysAPI.listPathwaysVersions();
@@ -350,33 +350,33 @@ describe('GTFS Pathways service', () => {
         expect(versions.status).toBe(200);
         versions.data.versions?.forEach(version => {
           expect(version).toMatchObject(<VersionSpec>{
-              version: expect.any(String),
-              documentation: expect.any(String),
-              specification: expect.any(String)
+            version: expect.any(String),
+            documentation: expect.any(String),
+            specification: expect.any(String)
           })
-      })
+        })
 
       })
     })
-    describe('Validation', ()=>{
-      it('When passed without token, should return 401 status', async () =>{
+    describe('Validation', () => {
+      it('When passed without token, should return 401 status', async () => {
         let pathwaysAPI = new GTFSPathwaysApi(Utility.getConfiguration());
 
-        let versions =  pathwaysAPI.listPathwaysVersions();
+        let versions = pathwaysAPI.listPathwaysVersions();
 
-        await expect(versions).rejects.toMatchObject({response:{status:401}});
+        await expect(versions).rejects.toMatchObject({ response: { status: 401 } });
       })
     })
   })
 
-  describe('Get a record for pathways', ()=>{
+  describe('Get a record for pathways', () => {
     describe('Functional', () => {
-      it('When passed with valid recordId, should be able to get the zip file', async ()=>{
-        
+      it('When passed with valid recordId, should be able to get the zip file', async () => {
+
         let pathwaysRecordId = '7cd301eb50ea413f90be12598d158149';
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
-        let response = await pathwaysAPI.getPathwaysFile(pathwaysRecordId,{responseType:'arraybuffer'});
+        let response = await pathwaysAPI.getPathwaysFile(pathwaysRecordId, { responseType: 'arraybuffer' });
         const data: any = response.data;
         const contentDisposition = response.headers['content-disposition'];
         const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
@@ -396,40 +396,40 @@ describe('GTFS Pathways service', () => {
 
     })
 
-    describe('Validation', ()=>{
-      it('When passed with valid recordId and invalid token, should return 401 status', async ()=>{
+    describe('Validation', () => {
+      it('When passed with valid recordId and invalid token, should return 401 status', async () => {
 
         let pathwaysRecordId = '7cd301eb50ea413f90be12598d158149';
         let pathwaysAPI = new GTFSPathwaysApi(Utility.getConfiguration());
 
         let response = pathwaysAPI.getPathwaysFile(pathwaysRecordId);
 
-        await expect(response).rejects.toMatchObject({response:{status:401}});
+        await expect(response).rejects.toMatchObject({ response: { status: 401 } });
 
       })
 
-      it('When passed with invalid record and valid token, should return 404 status', async () =>{
+      it('When passed with invalid record and valid token, should return 404 status', async () => {
 
         let pathwaysRecordId = 'dummyRecordId';
         let pathwaysAPI = new GTFSPathwaysApi(configuration);
 
         let response = pathwaysAPI.getPathwaysFile(pathwaysRecordId);
 
-        await expect(response).rejects.toMatchObject({response:{status:404}});
+        await expect(response).rejects.toMatchObject({ response: { status: 404 } });
 
       })
 
     })
-    
+
   })
 
 })
 
 function expectPolygon(polygon: any) {
   if (polygon) {
-      var aPolygon = polygon as GeoJsonObject;
-      expect(typeof aPolygon.features).not.toBeNull();
-      expect(aPolygon.features?.length).toBeGreaterThan(0);
+    var aPolygon = polygon as GeoJsonObject;
+    expect(typeof aPolygon.features).not.toBeNull();
+    expect(aPolygon.features?.length).toBeGreaterThan(0);
 
   }
 }

--- a/src/__tests__/osw.test.ts
+++ b/src/__tests__/osw.test.ts
@@ -1,4 +1,4 @@
-import { Feature, GeneralApi, GeoJsonObject, OSWApi, OswDownload, OswUpload, VersionSpec } from "tdei-client";
+import { AuthenticationApi, Feature, GeneralApi, GeoJsonObject, OSWApi, OswDownload, OswUpload, VersionSpec } from "tdei-client";
 import axios, { InternalAxiosRequestConfig } from "axios";
 import { Utility } from "../utils";
 import path from "path";
@@ -6,27 +6,27 @@ import * as fs from "fs";
 import AdmZip from "adm-zip";
 
 
-const DOWNLOAD_FILE_PATH = `${__dirname}/tmp`;
+const DOWNLOAD_FILE_PATH = `${__dirname}/osw-tmp`;
 describe('OSW service', () => {
   let configuration = Utility.getConfiguration();
   const NULL_PARAM = void 0;
-  const uploadRequestInterceptor = (request: InternalAxiosRequestConfig, fileName: string, metaToUpload:OswUpload) => {
+  const uploadRequestInterceptor = (request: InternalAxiosRequestConfig, fileName: string, metaToUpload: OswUpload) => {
     if (
-        request.url === `${configuration.basePath}/api/v1/osw`
+      request.url === `${configuration.basePath}/api/v1/osw`
     ) {
-        let data = request.data as FormData;
-        let file = data.get("file") as File;
-        delete data["file"];
-        delete data["meta"];
-        data.set("file", file, fileName);
-        data.set("meta", JSON.stringify(metaToUpload));
+      let data = request.data as FormData;
+      let file = data.get("file") as File;
+      delete data["file"];
+      delete data["meta"];
+      data.set("file", file, fileName);
+      data.set("meta", JSON.stringify(metaToUpload));
     }
     return request;
-};
+  };
 
   beforeAll(async () => {
-    let generalAPI = new GeneralApi(configuration);
-    const loginResponse = await generalAPI.authenticate({
+    let authAPI = new AuthenticationApi(configuration);
+    const loginResponse = await authAPI.authenticate({
       username: configuration.username,
       password: configuration.password
     });
@@ -38,13 +38,13 @@ describe('OSW service', () => {
     if (!fs.existsSync(DOWNLOAD_FILE_PATH)) {
       fs.mkdirSync(DOWNLOAD_FILE_PATH)
     } else {
-      fs.rmSync(DOWNLOAD_FILE_PATH, {recursive:true,force:true});
+      fs.rmSync(DOWNLOAD_FILE_PATH, { recursive: true, force: true });
       fs.mkdirSync(DOWNLOAD_FILE_PATH);
     }
   });
 
-  afterAll(async ()=>{
-    fs.rmSync(DOWNLOAD_FILE_PATH, {recursive:true,force:true});
+  afterAll(async () => {
+    fs.rmSync(DOWNLOAD_FILE_PATH, { recursive: true, force: true });
   })
 
   describe('List Files', () => {
@@ -63,24 +63,24 @@ describe('OSW service', () => {
             collection_date: expect.any(String),
             collection_method: expect.any(String),
             //TODO:
-           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
-           //TODO:
-         // publication_date: expect.any(String),
-          // confidence_level: expect.any(String),
-          data_source: expect.any(String),
-         polygon: expect.anything() as null | GeoJsonObject,
-          tdei_record_id: expect.any(String),
-          osw_schema_version: expect.any(String),
-          download_url: expect.any(String)
+            // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+            //TODO:
+            // publication_date: expect.any(String),
+            // confidence_level: expect.any(String),
+            data_source: expect.any(String),
+            polygon: expect.anything() as null | GeoJsonObject,
+            tdei_record_id: expect.any(String),
+            osw_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
       })
 
-      it('When passed with valid token and page size, should return 200 status with files less than or equal to 5', async () =>{
+      it('When passed with valid token and page size, should return 200 status with files less than or equal to 5', async () => {
         let oswAPI = new OSWApi(configuration);
         let page_size = 5;
 
-        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,page_size);
+        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, page_size);
 
         expect(oswFiles.status).toBe(200);
         expect(oswFiles.data.length).toBeLessThanOrEqual(page_size);
@@ -91,15 +91,15 @@ describe('OSW service', () => {
             collection_date: expect.any(String),
             collection_method: expect.any(String),
             //TODO:
-           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
-           //TODO:
-         // publication_date: expect.any(String),
-          // confidence_level: expect.any(String),
-          data_source: expect.any(String),
-         polygon: expect.anything() as null | GeoJsonObject,
-          tdei_record_id: expect.any(String),
-          osw_schema_version: expect.any(String),
-          download_url: expect.any(String)
+            // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+            //TODO:
+            // publication_date: expect.any(String),
+            // confidence_level: expect.any(String),
+            data_source: expect.any(String),
+            polygon: expect.anything() as null | GeoJsonObject,
+            tdei_record_id: expect.any(String),
+            osw_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
 
@@ -110,7 +110,7 @@ describe('OSW service', () => {
         //TODO: read from seeder or config
         let orgId = '5e339544-3b12-40a5-8acd-78c66d1fa981';
 
-        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM,NULL_PARAM,orgId);
+        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM, NULL_PARAM, orgId);
 
         expect(oswFiles.status).toBe(200);
         oswFiles.data.forEach(file => {
@@ -120,26 +120,26 @@ describe('OSW service', () => {
             collection_date: expect.any(String),
             collection_method: expect.any(String),
             //TODO:
-           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
-           //TODO:
-         // publication_date: expect.any(String),
-          // confidence_level: expect.any(String),
-          data_source: expect.any(String),
-         polygon: expect.anything() as null | GeoJsonObject,
-          tdei_record_id: expect.any(String),
-          osw_schema_version: expect.any(String),
-          download_url: expect.any(String)
+            // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+            //TODO:
+            // publication_date: expect.any(String),
+            // confidence_level: expect.any(String),
+            data_source: expect.any(String),
+            polygon: expect.anything() as null | GeoJsonObject,
+            tdei_record_id: expect.any(String),
+            osw_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
 
       })
 
-      it('When passed with valid token and valid recordId, should return 200 status with same record ID', async () =>{
+      it('When passed with valid token and valid recordId, should return 200 status with same record ID', async () => {
         let oswAPI = new OSWApi(configuration);
         //TODO: feed from seeder
         let recordId = '978203eeac334bdeba262899fce1fd8a';
 
-        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,recordId);
+        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, recordId);
 
         expect(oswFiles.status).toBe(200);
         expect(oswFiles.data.length).toBe(1);
@@ -150,15 +150,15 @@ describe('OSW service', () => {
             collection_date: expect.any(String),
             collection_method: expect.any(String),
             //TODO:
-           // collection_method: expect.any(OswDownloadCollectionMethodEnum),
-           //TODO:
-         // publication_date: expect.any(String),
-          // confidence_level: expect.any(String),
-          data_source: expect.any(String),
-         polygon: expect.anything() as null | GeoJsonObject,
-          tdei_record_id: recordId,
-          osw_schema_version: expect.any(String),
-          download_url: expect.any(String)
+            // collection_method: expect.any(OswDownloadCollectionMethodEnum),
+            //TODO:
+            // publication_date: expect.any(String),
+            // confidence_level: expect.any(String),
+            data_source: expect.any(String),
+            polygon: expect.anything() as null | GeoJsonObject,
+            tdei_record_id: recordId,
+            osw_schema_version: expect.any(String),
+            download_url: expect.any(String)
           })
         })
       })
@@ -166,85 +166,85 @@ describe('OSW service', () => {
     })
 
     describe('Validation', () => {
-      it('When passed with valid token and invalid recordId, should return 200 with 0 records', async () =>{
+      it('When passed with valid token and invalid recordId, should return 200 with 0 records', async () => {
         let oswAPI = new OSWApi(configuration);
         let recordId = 'dummyRecordId';
 
-        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM,NULL_PARAM,NULL_PARAM,NULL_PARAM,recordId);
+        const oswFiles = await oswAPI.listOswFiles(NULL_PARAM, NULL_PARAM, NULL_PARAM, NULL_PARAM, recordId);
 
         expect(oswFiles.status).toBe(200);
         expect(oswFiles.data.length).toBe(0);
 
       })
 
-      it('When passed without valid token, should reject with 401 status', async () =>{
+      it('When passed without valid token, should reject with 401 status', async () => {
         let oswAPI = new OSWApi(Utility.getConfiguration());
 
         const oswFiles = oswAPI.listOswFiles();
 
-        await expect(oswFiles).rejects.toMatchObject({response:{status:401}});
+        await expect(oswFiles).rejects.toMatchObject({ response: { status: 401 } });
       })
 
     })
 
   })
 
-  describe('Post file', ()=>{
-    describe('Functional', ()=>{
-      it('When passed with valid token, metadata and file, should return 202 status with recordId in response', async ()=>{
+  describe('Post file', () => {
+    describe('Functional', () => {
+      it('When passed with valid token, metadata and file, should return 202 status with recordId in response', async () => {
         let oswAPI = new OSWApi(configuration);
         let metaToUpload = Utility.getRandomOswUpload();
-        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "flex-test-upload.zip",metaToUpload))
+        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "flex-test-upload.zip", metaToUpload))
         //TODO: feed from seeder or configuration
         metaToUpload.tdei_org_id = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
         let fileBlob = Utility.getOSWBlob();
-        
-        const uploadedFileResponse = await oswAPI.uploadOswFileForm(metaToUpload,fileBlob);
+
+        const uploadedFileResponse = await oswAPI.uploadOswFileForm(metaToUpload, fileBlob);
 
         expect(uploadedFileResponse.status).toBe(202);
         expect(uploadedFileResponse.data != "").toBe(true);
-            
+
         axios.interceptors.request.eject(uploadInterceptor);
 
       }, 20000)
 
-      it('When passed with valid token, invalid metadata and file, should return 400 status in response', async ()=>{
+      it('When passed with valid token, invalid metadata and file, should return 400 status in response', async () => {
         let oswAPI = new OSWApi(configuration);
         let metaToUpload = Utility.getRandomOswUpload();
-        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "flex-test-upload.zip",metaToUpload))
+        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "flex-test-upload.zip", metaToUpload))
         //TODO: feed from seeder or configuration
         metaToUpload.tdei_org_id = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
         metaToUpload.collection_date = "";
         let fileBlob = Utility.getOSWBlob();
-        
-        const uploadedFileResponse =  oswAPI.uploadOswFileForm(metaToUpload,fileBlob);
 
-        await expect(uploadedFileResponse).rejects.toMatchObject({response:{status:400}});
-            
+        const uploadedFileResponse = oswAPI.uploadOswFileForm(metaToUpload, fileBlob);
+
+        await expect(uploadedFileResponse).rejects.toMatchObject({ response: { status: 400 } });
+
         axios.interceptors.request.eject(uploadInterceptor);
 
       }, 20000)
 
-      it('When passed without valid token, metadata and file, should return 401 status in response', async ()=>{
+      it('When passed without valid token, metadata and file, should return 401 status in response', async () => {
         let oswAPI = new OSWApi(Utility.getConfiguration());
         let metaToUpload = Utility.getRandomOswUpload();
-        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) =>uploadRequestInterceptor(req, "flex-test-upload.zip",metaToUpload))
+        const uploadInterceptor = axios.interceptors.request.use((req: InternalAxiosRequestConfig) => uploadRequestInterceptor(req, "flex-test-upload.zip", metaToUpload))
         //TODO: feed from seeder or configuraiton
         metaToUpload.tdei_org_id = 'c552d5d1-0719-4647-b86d-6ae9b25327b7';
         let fileBlob = Utility.getOSWBlob();
-        
-        const uploadedFileResponse =  oswAPI.uploadOswFileForm(metaToUpload,fileBlob);
 
-        await expect(uploadedFileResponse).rejects.toMatchObject({response:{status:401}});
-            
+        const uploadedFileResponse = oswAPI.uploadOswFileForm(metaToUpload, fileBlob);
+
+        await expect(uploadedFileResponse).rejects.toMatchObject({ response: { status: 401 } });
+
         axios.interceptors.request.eject(uploadInterceptor);
 
       }, 20000)
 
     })
   })
-  describe('List OSW Versions', () =>{
-    it('When passed with valid token, should respond with 200 status', async () =>{
+  describe('List OSW Versions', () => {
+    it('When passed with valid token, should respond with 200 status', async () => {
       let oswAPI = new OSWApi(configuration);
 
       let oswVersions = await oswAPI.listOswVersions();
@@ -253,32 +253,32 @@ describe('OSW service', () => {
       expect(Array.isArray(oswVersions.data.versions)).toBe(true);
       oswVersions.data.versions?.forEach(version => {
         expect(version).toMatchObject(<VersionSpec>{
-            version: expect.any(String),
-            documentation: expect.any(String),
-            specification: expect.any(String)
+          version: expect.any(String),
+          documentation: expect.any(String),
+          specification: expect.any(String)
         })
-    })
-      
-      
+      })
+
+
     })
 
-    it('When passed without valid token, should respond with 401 status', async () =>{
+    it('When passed without valid token, should respond with 401 status', async () => {
       let oswAPI = new OSWApi(Utility.getConfiguration());
 
       let oswVersionsResponse = oswAPI.listOswVersions();
 
-      await expect(oswVersionsResponse).rejects.toMatchObject({response:{status:401}});
+      await expect(oswVersionsResponse).rejects.toMatchObject({ response: { status: 401 } });
     })
   })
 
-  describe('Get a record for OSW', ()=>{
+  describe('Get a record for OSW', () => {
     describe('Functional', () => {
-      it('When passed with valid recordId, should be able to get the zip file', async ()=>{
-        
+      it('When passed with valid recordId, should be able to get the zip file', async () => {
+
         let oswRecordId = '8ec3e5c760024640ade1c7acce9ad9b6';
         let oswAPI = new OSWApi(configuration);
 
-        let response = await oswAPI.getOswFile(oswRecordId,{responseType:'arraybuffer'});
+        let response = await oswAPI.getOswFile(oswRecordId, { responseType: 'arraybuffer' });
         const data: any = response.data;
         const contentDisposition = response.headers['content-disposition'];
         const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
@@ -298,31 +298,31 @@ describe('OSW service', () => {
 
     })
 
-    describe('Validation', ()=>{
-      it('When passed with valid recordId and invalid token, should return 401 status', async ()=>{
+    describe('Validation', () => {
+      it('When passed with valid recordId and invalid token, should return 401 status', async () => {
 
         let oswRecordId = '8ec3e5c760024640ade1c7acce9ad9b6';
         let oswAPI = new OSWApi(Utility.getConfiguration());
 
         let response = oswAPI.getOswFile(oswRecordId);
 
-        await expect(response).rejects.toMatchObject({response:{status:401}});
+        await expect(response).rejects.toMatchObject({ response: { status: 401 } });
 
       })
 
-      it('When passed with invalid record and valid token, should return 404 status', async () =>{
+      it('When passed with invalid record and valid token, should return 404 status', async () => {
 
         let oswRecordId = 'dummyRecordId';
         let oswAPI = new OSWApi(configuration);
 
         let response = oswAPI.getOswFile(oswRecordId);
 
-        await expect(response).rejects.toMatchObject({response:{status:404}});
+        await expect(response).rejects.toMatchObject({ response: { status: 404 } });
 
       })
 
     })
-    
+
   })
 
 })


### PR DESCRIPTION
1. Flex, OSW, Pathways for upload the temp folder was shared which was making test inconsistent on each run , changed code to have different folder for each file type
2. There was invalid test case for GET Organization filter which is commented now
3. Indentation fixes
4. Separated Authentication tests from general 